### PR TITLE
fix: 统一 UTF-8 编码并修复后端中文乱码

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.sqlite binary

--- a/backend/index.js
+++ b/backend/index.js
@@ -8,7 +8,7 @@ const commentsRouter = require("./routes/comments");
 const usersRouter = require("./routes/users");
 
 const app = express();
-const PORT = 3000; // ºó¶Ë¼àÌı¶Ë¿Ú
+const PORT = 3000; // ç¤ºä¾‹æœåŠ¡ç«¯å£
 
 app.use(cors());
 app.use(bodyParser.json());

--- a/backend/routes/comments.js
+++ b/backend/routes/comments.js
@@ -2,7 +2,7 @@ const express = require("express");
 const router = express.Router();
 const { db } = require("../db");
 
-// »ñÈ¡Ä³µØµãÆÀÂÛ
+// èŽ·å–æŸåœ°ç‚¹çš„è¯„è®º
 router.get("/place/:placeId", (req, res) => {
     const { placeId } = req.params;
     db.all("SELECT * FROM Comment WHERE place_id = ? ORDER BY time DESC", [placeId], (err, rows) => {
@@ -11,11 +11,11 @@ router.get("/place/:placeId", (req, res) => {
     });
 });
 
-// Ìí¼ÓÆÀÂÛ
+// æ·»åŠ è¯„è®º
 router.post("/", (req, res) => {
     const { place_id, content, rating } = req.body;
     const userId = req.header("X-User-Id") || null;
-    if (!place_id || !content) return res.status(400).json({ error: "È±ÉÙ±ØÐè×Ö¶Î" });
+    if (!place_id || !content) return res.status(400).json({ error: "ç¼ºå°‘å¿…å¡«å­—æ®µ" });
     db.run("INSERT INTO Comment (place_id, user_id, content, rating) VALUES (?, ?, ?, ?)",
         [place_id, userId, content, rating || null],
         function (err) {

--- a/backend/routes/places.js
+++ b/backend/routes/places.js
@@ -2,7 +2,7 @@ const express = require("express");
 const router = express.Router();
 const { db } = require("../db");
 
-// ÁĞ³öËùÓĞµØµã
+// åˆ—å‡ºæ‰€æœ‰åœ°ç‚¹
 router.get("/", (req, res) => {
     db.all("SELECT * FROM Place ORDER BY created_time DESC", [], (err, rows) => {
         if (err) return res.status(500).json({ error: err.message });
@@ -10,10 +10,10 @@ router.get("/", (req, res) => {
     });
 });
 
-// ¸ù¾İ bounds ²éÑ¯£¨·¶Î§ËÑË÷£©
+// æŒ‰ bounds æŸ¥è¯¢èŒƒå›´å†…åœ°ç‚¹
 router.get("/nearby", (req, res) => {
     const { minLng, minLat, maxLng, maxLat } = req.query;
-    if (![minLng, minLat, maxLng, maxLat].every(Boolean)) return res.status(400).json({ error: "È±ÉÙ·¶Î§²ÎÊı" });
+    if (![minLng, minLat, maxLng, maxLat].every(Boolean)) return res.status(400).json({ error: "ç¼ºå°‘èŒƒå›´å‚æ•°" });
     const sql = `SELECT * FROM Place WHERE longitude BETWEEN ? AND ? AND latitude BETWEEN ? AND ?`;
     db.all(sql, [minLng, maxLng, minLat, maxLat], (err, rows) => {
         if (err) return res.status(500).json({ error: err.message });
@@ -21,11 +21,11 @@ router.get("/nearby", (req, res) => {
     });
 });
 
-// Ìí¼ÓµØµã
+// æ·»åŠ åœ°ç‚¹
 router.post("/", (req, res) => {
     const { name, description, latitude, longitude, category } = req.body;
     const creatorId = req.header("X-User-Id") || null;
-    if (!name || !latitude || !longitude) return res.status(400).json({ error: "È±ÉÙ±ØĞè×Ö¶Î" });
+    if (!name || !latitude || !longitude) return res.status(400).json({ error: "ç¼ºå°‘å¿…å¡«å­—æ®µ" });
 
     const sql = `INSERT INTO Place (name, description, latitude, longitude, category, creator_id) VALUES (?, ?, ?, ?, ?, ?)`;
     db.run(sql, [name, description || "", latitude, longitude, category || "", creatorId], function (err) {
@@ -37,16 +37,16 @@ router.post("/", (req, res) => {
     });
 });
 
-// É¾³ıµØµã£¨½ö´´½¨Õß»ò¹ÜÀíÔ±£©
+// åˆ é™¤åœ°ç‚¹ï¼ˆä»…åˆ›å»ºè€…æˆ–ç®¡ç†å‘˜ï¼‰
 router.delete("/:id", (req, res) => {
     const id = req.params.id;
     const requester = req.header("X-User-Id");
-    // ¼òµ¥ÑéÖ¤£ºÈç¹û requester === creator_id »ò requester === "admin" ÔòÔÊĞí
+    // æƒé™éªŒè¯ï¼šè¦æ±‚ requester === creator_id æˆ– requester === "admin"
     db.get("SELECT * FROM Place WHERE id = ?", [id], (err, place) => {
         if (err) return res.status(500).json({ error: err.message });
         if (!place) return res.status(404).json({ error: "Not found" });
         if (String(place.creator_id) !== String(requester) && requester !== "admin") {
-            return res.status(403).json({ error: "Ã»ÓĞÈ¨ÏŞÉ¾³ı" });
+            return res.status(403).json({ error: "æ²¡æœ‰æƒé™åˆ é™¤" });
         }
         db.run("DELETE FROM Place WHERE id = ?", [id], function (e) {
             if (e) return res.status(500).json({ error: e.message });

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -3,10 +3,10 @@ const router = express.Router();
 const { db } = require("../db");
 
 // AIGC
-// ¼òµ¥ÓÃ»§×¢²á£¨Éú²úÇë¹şÏ£ÃÜÂë²¢Ìí¼ÓÑéÖ¤£©
+// ç”¨æˆ·æ³¨å†Œï¼ˆç¤ºä¾‹ç”¨é€”ï¼Œå¯†ç åº”åŠ å¯†å­˜å‚¨ï¼‰
 router.post("/register", (req, res) => {
     const { username, password } = req.body;
-    if (!username || !password) return res.status(400).json({ error: "È±ÉÙ×Ö¶Î" });
+    if (!username || !password) return res.status(400).json({ error: "ç¼ºå°‘å­—æ®µ" });
     db.run("INSERT INTO User (username, password) VALUES (?, ?)", [username, password], function (err) {
         if (err) return res.status(500).json({ error: err.message });
         db.get("SELECT id, username FROM User WHERE id = ?", [this.lastID], (e, row) => {
@@ -16,12 +16,12 @@ router.post("/register", (req, res) => {
     });
 });
 
-// ¼òµ¥µÇÂ¼£¨·µ»Ø user id£©
+// ç®€å•ç™»å½•ï¼ˆè¿”å› user idï¼‰
 router.post("/login", (req, res) => {
     const { username, password } = req.body;
     db.get("SELECT id, username FROM User WHERE username = ? AND password = ?", [username, password], (err, row) => {
         if (err) return res.status(500).json({ error: err.message });
-        if (!row) return res.status(401).json({ error: "ÓÃ»§Ãû»òÃÜÂë´íÎó" });
+        if (!row) return res.status(401).json({ error: "ç”¨æˆ·åæˆ–å¯†ç é”™è¯¯" });
         res.json(row);
     });
 });


### PR DESCRIPTION
## 变更说明
- 修复后端 4 个路由文件与  中的中文乱码文本
- 将上述文件统一为 UTF-8 编码，避免在 macOS/Linux 中出现乱码
- 新增 ，统一文本文件为 UTF-8 + LF
- 新增 ，统一文本换行策略并声明二进制文件类型

## 说明
- 不包含业务逻辑变更，仅编码与文案修复
- 未包含本地  与  未跟踪文件