### PR TITLE
fix(frontend): 修复 iPhone 与 iPad 地图视口比例异常

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,8 +6,12 @@
         <title>东方饭联地图</title>
         <script src="https://webapi.amap.com/maps?v=2.0&key=c92da5ff295d79be6e55c3dd2946a272"></script>
         <style>
-            html,body,#root { height: 100%; margin: 0; padding: 0; }
-            #map { width: 100%; height: 100dvh; height: 100vh; }
+            :root { --app-height: 100vh; }
+            @supports (height: 100dvh) {
+                :root { --app-height: 100dvh; }
+            }
+            html,body,#root { height: 100%; min-height: 100%; margin: 0; padding: 0; }
+            #map { width: 100%; height: 100%; }
             .panel { position: absolute; top: 8px; left: 8px; z-index: 2000; background: white; padding: 8px; border-radius: 4px; box-shadow: 0 2px 8px rgba(0,0,0,0.2); }
             input, textarea, select { font-size: 16px; }
         </style>

--- a/frontend/src/AdminDashboard.jsx
+++ b/frontend/src/AdminDashboard.jsx
@@ -12,7 +12,7 @@ export default function AdminDashboard({ user, onBackHome, onLogout }) {
     const perms = level ? (PERMISSIONS[level] || []) : [];
 
     return (
-        <div style={{ minHeight: "100vh", background: "#f6f7f9", padding: 20, boxSizing: "border-box" }}>
+        <div style={{ minHeight: "var(--app-height, 100vh)", background: "#f6f7f9", padding: 20, boxSizing: "border-box" }}>
             <div style={{ maxWidth: 760, margin: "0 auto" }}>
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
                     <h2 style={{ margin: 0 }}>管理员后台</h2>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -84,6 +84,33 @@ export default function App() {
     }, []);
 
     useEffect(() => {
+        if (typeof document === "undefined" || typeof window === "undefined") return;
+
+        const root = document.documentElement;
+        const updateViewportHeight = () => {
+            const viewportHeight = window.visualViewport ? window.visualViewport.height : window.innerHeight;
+            root.style.setProperty("--app-height", `${Math.round(viewportHeight)}px`);
+        };
+
+        updateViewportHeight();
+
+        const visualViewport = window.visualViewport;
+        window.addEventListener("resize", updateViewportHeight);
+        window.addEventListener("orientationchange", updateViewportHeight);
+        if (visualViewport) {
+            visualViewport.addEventListener("resize", updateViewportHeight);
+        }
+
+        return () => {
+            window.removeEventListener("resize", updateViewportHeight);
+            window.removeEventListener("orientationchange", updateViewportHeight);
+            if (visualViewport) {
+                visualViewport.removeEventListener("resize", updateViewportHeight);
+            }
+        };
+    }, []);
+
+    useEffect(() => {
         // 如果有 token 但没有 user，就向后端请求 /users/me 获取用户信息
         if (!token || user) return;
 
@@ -125,14 +152,14 @@ export default function App() {
     const showAdminPage = pathname === "/admin" && !!token;
 
     return (
-        <div style={{ height: "100vh", position: "relative" }}>
+        <div style={{ height: "var(--app-height, 100vh)", position: "relative" }}>
             {!showAdminPage && <MapView userId={user ? user.id : null} backendUrl={BACKEND_URL} />}
 
             {showAdminPage && (
                 user ? (
                     <AdminDashboard user={user} onBackHome={() => goPath("/")} onLogout={handleLogout} />
                 ) : (
-                    <div style={{ minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center" }}>
+                    <div style={{ minHeight: "var(--app-height, 100vh)", display: "flex", alignItems: "center", justifyContent: "center" }}>
                         正在验证登录状态...
                     </div>
                 )

--- a/frontend/src/AuthPage.jsx
+++ b/frontend/src/AuthPage.jsx
@@ -230,7 +230,7 @@ export default function AuthPage({ backendUrl, onLoginSuccess, onClose }) {
             onMouseDown={(e) => e.stopPropagation()}
             style={{
                 width: "min(420px, calc(100vw - 32px))",
-                maxHeight: "calc(100vh - 32px)",
+                maxHeight: "calc(var(--app-height, 100vh) - 32px)",
                 overflowY: "auto",
                 background: UI_COLORS.panelBackground,
                 padding: 18,

--- a/frontend/src/Map.jsx
+++ b/frontend/src/Map.jsx
@@ -100,6 +100,7 @@ export default function MapView({ backendUrl, userId }) {
         let handleVisibilityChange = null;
         let handleUpdatePopup = null;
         let handleResize = null;
+        let resizeObserver = null;
 
         const getCurrentMapView = () => {
             if (!mapRef.current) return null;
@@ -193,6 +194,9 @@ export default function MapView({ backendUrl, userId }) {
                 setPopupPoint(point);
             };
             handleResize = () => {
+                if (mapRef.current && typeof mapRef.current.resize === "function") {
+                    mapRef.current.resize();
+                }
                 handleUpdatePopup();
             };
 
@@ -202,6 +206,12 @@ export default function MapView({ backendUrl, userId }) {
             mapRef.current.on("moveend", handleUpdatePopup);
             mapRef.current.on("zoomend", handleUpdatePopup);
             window.addEventListener("resize", handleResize);
+            if (containerRef.current && typeof ResizeObserver !== "undefined") {
+                resizeObserver = new ResizeObserver(() => {
+                    handleResize();
+                });
+                resizeObserver.observe(containerRef.current);
+            }
 
             window.addEventListener("pagehide", handlePageHide);
             document.addEventListener("visibilitychange", handleVisibilityChange);
@@ -244,6 +254,7 @@ export default function MapView({ backendUrl, userId }) {
                 document.removeEventListener("visibilitychange", handleVisibilityChange);
             }
             if (handleResize) window.removeEventListener("resize", handleResize);
+            if (resizeObserver) resizeObserver.disconnect();
         };
     }, []);
 


### PR DESCRIPTION
## 变更说明
- 修复 iPhone 与 iPad 上地图页使用 100vh 导致可视区高度与真实视口不一致的问题
- 使用 --app-height 与 visualViewport 同步实际视口高度
- 在地图容器尺寸变化时主动触发 resize，减少 iOS Safari 地址栏变化后的比例异常

## 验证
- npm run build

## 补充说明
- 提出方反馈：已在 iPad 和 iPhone 上分别完成测试
