### PR TITLE
feat: 所有写接口统一接入服务端鉴权

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -62,7 +62,7 @@ app.use(cors({
         return callback(new Error('Not allowed by CORS'));
     },
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'X-User-Id'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
     credentials: true,
     maxAge: 3600
 }));

--- a/backend/middleware/adminAuth.js
+++ b/backend/middleware/adminAuth.js
@@ -1,12 +1,11 @@
-const PERMISSIONS = require("../utils/adminPermissions");
+const { hasPermission } = require("../utils/adminPermissions");
 
 function requireAdmin(permission) {
     return function (req, res, next) {
         const user = req.user;
         if (!user) return res.status(401).json({ error: "未登录或授权已失效" });
         if (!user.admin_level) return res.status(403).json({ error: "无管理员权限" });
-        const allowed = PERMISSIONS[user.admin_level] || [];
-        if (!allowed.includes(permission)) return res.status(403).json({ error: "无此操作权限" });
+        if (!hasPermission(user, permission)) return res.status(403).json({ error: "无此操作权限" });
         next();
     };
 }

--- a/backend/routes/comments.js
+++ b/backend/routes/comments.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const { db } = require("../db");
+const { requireAuth } = require("../middleware/auth");
 
 // 获取某地点的评论
 router.get("/place/:placeId", (req, res) => {
@@ -12,19 +13,23 @@ router.get("/place/:placeId", (req, res) => {
 });
 
 // 添加评论
-router.post("/", (req, res) => {
+router.post("/", requireAuth, (req, res) => {
     const { place_id, content, rating } = req.body;
-    const userId = req.header("X-User-Id") || null;
     if (!place_id || !content) return res.status(400).json({ error: "缺少必填字段" });
-    db.run("INSERT INTO Comment (place_id, user_id, content, rating) VALUES (?, ?, ?, ?)",
-        [place_id, userId, content, rating || null],
-        function (err) {
-            if (err) return res.status(500).json({ error: err.message });
-            db.get("SELECT * FROM Comment WHERE id = ?", [this.lastID], (e, row) => {
-                if (e) return res.status(500).json({ error: e.message });
-                res.json(row);
+    db.get("SELECT id FROM Place WHERE id = ?", [place_id], (placeErr, place) => {
+        if (placeErr) return res.status(500).json({ error: placeErr.message });
+        if (!place) return res.status(404).json({ error: "地点不存在" });
+
+        db.run("INSERT INTO Comment (place_id, user_id, content, rating) VALUES (?, ?, ?, ?)",
+            [place_id, req.user.id, content, rating || null],
+            function (err) {
+                if (err) return res.status(500).json({ error: err.message });
+                db.get("SELECT * FROM Comment WHERE id = ?", [this.lastID], (e, row) => {
+                    if (e) return res.status(500).json({ error: e.message });
+                    res.json(row);
+                });
             });
-        });
+    });
 });
 
 module.exports = router;

--- a/backend/routes/places.js
+++ b/backend/routes/places.js
@@ -1,6 +1,8 @@
 const express = require("express");
 const router = express.Router();
 const { db } = require("../db");
+const { requireAuth } = require("../middleware/auth");
+const { hasPermission } = require("../utils/adminPermissions");
 
 // 列出所有地点
 router.get("/", (req, res) => {
@@ -22,9 +24,9 @@ router.get("/nearby", (req, res) => {
 });
 
 // 添加地点
-router.post("/", (req, res) => {
+router.post("/", requireAuth, (req, res) => {
     const { name, description, latitude, longitude, category } = req.body;
-    const creatorId = req.header("X-User-Id") || null;
+    const creatorId = req.user.id;
     if (!name || !latitude || !longitude) return res.status(400).json({ error: "缺少必填字段" });
 
     const sql = `INSERT INTO Place (name, description, latitude, longitude, category, creator_id) VALUES (?, ?, ?, ?, ?, ?)`;
@@ -38,14 +40,14 @@ router.post("/", (req, res) => {
 });
 
 // 删除地点（仅创建者或管理员）
-router.delete("/:id", (req, res) => {
+router.delete("/:id", requireAuth, (req, res) => {
     const id = req.params.id;
-    const requester = req.header("X-User-Id");
-    // 权限验证：要求 requester === creator_id 或 requester === "admin"
     db.get("SELECT * FROM Place WHERE id = ?", [id], (err, place) => {
         if (err) return res.status(500).json({ error: err.message });
-        if (!place) return res.status(404).json({ error: "Not found" });
-        if (String(place.creator_id) !== String(requester) && requester !== "admin") {
+        if (!place) return res.status(404).json({ error: "地点不存在" });
+        const isCreator = String(place.creator_id) === String(req.user.id);
+        const canManagePlaces = hasPermission(req.user, "manage_places");
+        if (!isCreator && !canManagePlaces) {
             return res.status(403).json({ error: "没有权限删除" });
         }
         db.run("DELETE FROM Place WHERE id = ?", [id], function (e) {

--- a/backend/utils/adminPermissions.js
+++ b/backend/utils/adminPermissions.js
@@ -4,4 +4,18 @@ const PERMISSIONS = {
     KOMACHI: ["manage_users_general", "manage_comments"]
 };
 
-module.exports = PERMISSIONS;
+function getPermissionsForLevel(adminLevel) {
+    if (!adminLevel) return [];
+    return PERMISSIONS[adminLevel] || [];
+}
+
+function hasPermission(user, permission) {
+    if (!user || !permission) return false;
+    return getPermissionsForLevel(user.admin_level).includes(permission);
+}
+
+module.exports = {
+    PERMISSIONS,
+    getPermissionsForLevel,
+    hasPermission
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -153,7 +153,14 @@ export default function App() {
 
     return (
         <div style={{ height: "var(--app-height, 100vh)", position: "relative" }}>
-            {!showAdminPage && <MapView userId={user ? user.id : null} backendUrl={BACKEND_URL} />}
+            {!showAdminPage && (
+                <MapView
+                    backendUrl={BACKEND_URL}
+                    token={token}
+                    isAuthenticated={isAuth}
+                    onRequireAuth={() => setShowAuth(true)}
+                />
+            )}
 
             {showAdminPage && (
                 user ? (

--- a/frontend/src/Map.jsx
+++ b/frontend/src/Map.jsx
@@ -96,7 +96,7 @@ function shouldPersistMapView(prevView, nextView) {
     return haversineDistanceMeters(prevView, nextView) >= MIN_CENTER_SAVE_DISTANCE_METERS;
 }
 
-export default function MapView({ backendUrl, userId }) {
+export default function MapView({ backendUrl, token, isAuthenticated, onRequireAuth }) {
     const containerRef = useRef(null);  // 引用地图容器
     const mapRef = useRef(null);        // 存储 AMap 实例
     const markersRef = useRef([]);      // 存储当前地图上的 marker 实例，方便更新时清除旧 marker
@@ -119,6 +119,9 @@ export default function MapView({ backendUrl, userId }) {
     const [selectedPlace, setSelectedPlace] = useState(null); // 被选中的地点对象（来自 places）
     const [popupPoint, setPopupPoint] = useState(null); // { x, y } 相对于地图容器的像素位置
     const selectedPlaceRef = useRef(null);
+    const hasToken = !!token;
+    const authPending = hasToken && !isAuthenticated;
+    const canWrite = hasToken && isAuthenticated;
 
     const tipText = mapReady ? "点击查找地点" : "地图尚未就绪，稍候再试"; // 查找功能 tooltip 提示
     const locationTipText = !mapReady
@@ -126,6 +129,13 @@ export default function MapView({ backendUrl, userId }) {
         : (locationError || (canUseLocationInCurrentContext()
             ? "点击获取当前位置并在地图上标记"
             : "定位功能仅在 HTTPS 或 localhost 环境下可用"));
+    const addPlaceTipText = !mapReady
+        ? "地图尚未就绪，稍候再试"
+        : authPending
+            ? "正在验证登录状态，请稍候再试"
+            : canWrite
+                ? (addMode ? "点击取消添加模式" : "点击后在地图上选择位置以添加地点")
+                : "登录后才能添加地点";
 
     // 同步 ref，以便地图上的 click handler 总能读取到最新的 addMode
     useEffect(() => {
@@ -134,6 +144,12 @@ export default function MapView({ backendUrl, userId }) {
             containerRef.current.style.cursor = addMode ? "crosshair" : "";
         }
     }, [addMode]);
+
+    useEffect(() => {
+        if (canWrite) return;
+        if (addMode) setAddMode(false);
+        if (addingPos) setAddingPos(null);
+    }, [canWrite, addMode, addingPos]);
 
     useEffect(() => {
         let pollTimer = null;
@@ -465,20 +481,28 @@ export default function MapView({ backendUrl, userId }) {
     }, [searchResults, places]);
 
     const submitPlace = async (payload) => {
+        if (!token) {
+            onRequireAuth && onRequireAuth();
+            return;
+        }
+
         try {
             const res = await fetch(`${backendUrl}/places`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    "X-User-Id": String(userId)
+                    Authorization: `Bearer ${token}`
                 },
                 body: JSON.stringify(payload)
             });
             if (!res.ok) {
+                if (res.status === 401) {
+                    onRequireAuth && onRequireAuth();
+                }
                 const text = await res.text().catch(() => "");
                 throw new Error(`后端错误 ${res.status} ${res.statusText} ${text}`);
             }
-            const saved = await res.json();
+            await res.json();
             setAddingPos(null);
             // 重新加载数据并清除搜索结果（若正在搜索）
             await loadPlaces();
@@ -541,6 +565,15 @@ export default function MapView({ backendUrl, userId }) {
         setSearchResults(null);
         setSearching(false);
         await loadPlaces();
+    };
+
+    const handleToggleAddMode = () => {
+        if (!mapReady || authPending) return;
+        if (!canWrite) {
+            onRequireAuth && onRequireAuth();
+            return;
+        }
+        setAddMode((v) => !v);
     };
 
     const handleCreateAtCenter = () => {
@@ -660,17 +693,21 @@ export default function MapView({ backendUrl, userId }) {
                         </div>
                     </Tooltip>
                     <div style={{ display: "inline-block" }}>
-                        <Button
-                            onClick={() => setAddMode((v) => !v)}
-                            disabled={!mapReady}
-                            title={addMode ? "点击取消添加模式" : "点击后在地图上选择位置以添加地点"}
-                            style={{
-                                background: addMode ? "#f0ad4e" : undefined,
-                                color: addMode ? "#fff" : undefined
-                            }}
-                        >
-                            {addMode ? "取消添加" : "添加地点"}
-                        </Button>
+                        <Tooltip text={addPlaceTipText} placement="top">
+                            <div style={{ display: "inline-block" }}>
+                                <Button
+                                    onClick={handleToggleAddMode}
+                                    disabled={!mapReady || authPending}
+                                    title={addPlaceTipText}
+                                    style={{
+                                        background: addMode ? "#f0ad4e" : undefined,
+                                        color: addMode ? "#fff" : undefined
+                                    }}
+                                >
+                                    {addMode ? "取消添加" : "添加地点"}
+                                </Button>
+                            </div>
+                        </Tooltip>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## 概要
- 给 `POST /places`、`DELETE /places/:id`、`POST /comments` 统一接入服务端 `requireAuth`
- 移除业务写接口对 `X-User-Id` 的信任，统一改为只使用 `req.user.id`
- 抽取可复用的管理员权限判断函数，地点删除改为“创建者本人或具备 `manage_places` 权限的管理员”
- 前端地图写入链路切到 `Authorization: Bearer <token>`，未登录点击添加地点时直接拉起登录
- CORS `allowedHeaders` 去掉 `X-User-Id`

## 验证
- `node --check index.js`
- `node --check routes/places.js`
- `node --check routes/comments.js`
- `node --check middleware/adminAuth.js`
- `node --check utils/adminPermissions.js`
- `npm run build`
- 本地冒烟验证：匿名 `POST /places` / `POST /comments` 返回 `401`
- 本地冒烟验证：登录后创建地点成功，`creator_id` 与 token 用户一致
- 本地冒烟验证：普通用户删除他人地点返回 `403`
- 本地冒烟验证：具备 `manage_places` 权限的管理员可删除他人地点
- 本地冒烟验证：登录用户对不存在地点评论返回 `404`，对存在地点评论成功